### PR TITLE
Fixed axon-server reference in docker-compose.yaml

### DIFF
--- a/infrastructure/light/docker-compose.yaml
+++ b/infrastructure/light/docker-compose.yaml
@@ -144,7 +144,7 @@ services:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
       - prometheus-storage:/prometheus
     depends_on:
-      - axon-server-1
+      - axon-server
     ports:
       - "9090:9090"
 
@@ -176,7 +176,7 @@ services:
     volumes:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf
     depends_on:
-      - axon-server-1
+      - axon-server
       - service-auction-object-registry
       - service-auction-query
       - service-auctions


### PR DESCRIPTION
`nginx` and `prometheus` were depending on `axon-server-1` while in this setup there is only a unique `axon-server`